### PR TITLE
feat(mappings): reintroduce the classification value in the result

### DIFF
--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -221,6 +221,16 @@ const mappings = [
     value: 'owner',
   },
 
+  // Klassifizierung
+  {
+    display_value: 'classification.classification',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'classification',
+    value: 'classification.classification',
+  },
+
   // Print Process
   {
     display_value: 'classification.printProcess',


### PR DESCRIPTION
Mit diesem PR wird der `classification`-Wert wieder in Ergebnissen mit aufgenommen, der für die Suche benötigt wird.