### PR TITLE
Mappings für involvedPersons und objectName

### DIFF
--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -229,6 +229,16 @@ const mappings = [
     value: 'inventoryNumber.keyword',
   },
 
+  // Object name
+  {
+    display_value: 'objectName.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'object_name',
+    value: 'objectName.keyword',
+  },
+
   // Eigentümer
   {
     display_value: 'owner',


### PR DESCRIPTION
Mit diesem PR werden die Daten für `involvedPersons` und `objectName` in den Ergebnissen mit aufgenommen.
Dies ist u.a. dafür notwendig, damit man in der Suche nicht mehr auf `data_all` zugreifen muss, um konkret auf die `involvedPersons`-Liste zugreifen zu können.
`objectName` wurde hingegen normal im Ergebnis erwartet, tauchte aber nirgendwo in den API-Mappings auf.