### PR TITLE
feat(mappings): add filterinfos-attribution mapping

### DIFF
--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -40,14 +40,14 @@ const mappings = [
 
   // Zuschreibung
   {
-    display_value: 'involvedPersons.name',
+    display_value: 'filterInfos.attribution.id',
     showAsFilter: true,
     showAsResult: true,
     filter_types: ['equals', 'notequals'],
     key: 'attribution',
-    value: 'involvedPersons.id.keyword',
-    nestedPath: 'involvedPersons',
-    sortBy: 'involvedPersons.displayOrder',
+    value: 'filterInfos.attribution.id',
+    nestedPath: 'filterInfos.attribution',
+    sortBy: 'filterInfos.attribution.order',
     filterInfos: true,
   },
 


### PR DESCRIPTION
Mit diesem PR wird für die Zuschreibung (Filter) auf `filterInfos.attribution` anstatt auf `involvedPersons.*`.
Der Grund dafür ist, dass über `involvedPersons` der (Tree-)Filter `Bekannte Meister der Cranach-Werkstatt` nicht abgebildet werden kann.
Ob ein Objekt eine involvierte Person aufweist, die ein bekannter Meister der Cranach-Werkstatt ist, wird aktuell zum Import-Vorgang bestimmt / abgeleitet und in `filterInfos.attribution` über einen zusätzlichen Eintrag hinterlegt.

Mit dieser Änderung ist leider auch eine Erweiterung der ES-Mappings notwendig: https://github.com/lucascranach/cranach-docker/pull/5