### PR TITLE
Katalog-Filter und -Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,11 @@ The `sortfield` is used to define the field by which the items are to be sorted.
 The items can be sorted ascending or descending.
 The parameter `sortdirection` must be set accordingly.  
 * `asc` = ascending order  
-* `des` = descending order  
+* `des` = descending order
+
+## Show Development Data
+
+To add all available fields to the result set use the `show_data_all=true` parameter within the query string.
+
+### Example
+https://mivs02.gm.fh-koeln.de/?size=20&show_data_all=true

--- a/src/server/assets/json/cda-filters.json
+++ b/src/server/assets/json/cda-filters.json
@@ -1976,6 +1976,14 @@
                                         "en": "Bayerisches Nationalmuseum"
                                     },
                                     "children": []
+                                },
+                                {
+                                    "id": "collection_repository.country.germany.munich.munich_3",
+                                    "text": {
+                                        "de": "Staatliche Graphische Sammlung M\u00fcnchen",
+                                        "en": "Staatliche Graphische Sammlung M\u00fcnchen"
+                                    },
+                                    "children": []
                                 }
                             ]
                         },
@@ -3792,6 +3800,57 @@
                 "en": "Stereomicroscopy"
             },
             "children": []
+        }
+    ],
+    "catalog": [
+        {
+            "id": "catalog.KKL",
+            "text": {
+                "de": "KKL",
+                "en": "KKL"
+            },
+            "children": [
+                {
+                    "id": "catalog.KKL.I",
+                    "text": {
+                        "de": "I.",
+                        "en": "I."
+                    },
+                    "children": []
+                },
+                {
+                    "id": "catalog.KKL.II",
+                    "text": {
+                        "de": "II.",
+                        "en": "II."
+                    },
+                    "children": []
+                },
+                {
+                    "id": "catalog.KKL.III",
+                    "text": {
+                        "de": "III.",
+                        "en": "III."
+                    },
+                    "children": []
+                },
+                {
+                    "id": "catalog.KKL.IV",
+                    "text": {
+                        "de": "IV.",
+                        "en": "IV."
+                    },
+                    "children": []
+                },
+                {
+                    "id": "catalog.KKL.V",
+                    "text": {
+                        "de": "V.",
+                        "en": "V."
+                    },
+                    "children": []
+                }
+            ]
         }
     ],
     "subject": [

--- a/src/server/assets/json/translations.json
+++ b/src/server/assets/json/translations.json
@@ -38,5 +38,9 @@
   "technique": {
     "de": "Technik",
     "en": "Technique"
+  },
+  "catalog": {
+    "de": "Katalog",
+    "en": "Catalog"
   }
 }

--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -62,22 +62,36 @@ const mappings = [
 
   // Sammlung / Standort
   {
-    display_value: 'filterInfos.collection_repository.id.keyword',
+    display_value: 'filterInfos.collection_repository.id',
     key: 'collection_repository',
     showAsFilter: true,
     showAsResult: false,
-    value: 'filterInfos.collection_repository.id.keyword',
+    value: 'filterInfos.collection_repository.id',
+    nestedPath: 'filterInfos.collection_repository',
     filter_types: ['equals', 'notequals'],
     filterInfos: true,
   },
 
   // Untersuchungstechniken
   {
-    display_value: 'filterInfos.examination_analysis.id.keyword',
+    display_value: 'filterInfos.examination_analysis.id',
     key: 'examination_analysis',
     showAsFilter: true,
     showAsResult: false,
-    value: 'filterInfos.examination_analysis.id.keyword',
+    value: 'filterInfos.examination_analysis.id',
+    nestedPath: 'filterInfos.examination_analysis',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Katalog
+  {
+    display_value: 'filterInfos.catalog.id',
+    key: 'catalog',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.catalog.id',
+    nestedPath: 'filterInfos.catalog',
     filter_types: ['equals', 'notequals'],
     filterInfos: true,
   },
@@ -271,11 +285,12 @@ const mappings = [
 
   // Inhalt
   {
-    display_value: 'filterInfos.subject.id.keyword',
+    display_value: 'filterInfos.subject.id',
     key: 'subject',
     showAsFilter: true,
     showAsResult: false,
-    value: 'filterInfos.subject.id.keyword',
+    value: 'filterInfos.subject.id',
+    nestedPath: 'filterInfos.subject',
     filter_types: ['equals', 'notequals'],
     filterInfos: true,
   },


### PR DESCRIPTION
Mit diesem PR wird der Katalog-Filter eingeführt und die die dafür möglichen Filter-Werte in der Filter-JSON-Datei ergänzt.
Zudem werden weitere Filter-Mappings leicht angepasst, um einen Bug bei Filtern zu beheben, die Unterfilter aufweisen können.