### PR TITLE
Adds soft ranges for filters 'dating_begin' and 'dating_end'

### DIFF
--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -152,7 +152,7 @@ const mappings = [
   {
     display_value: 'dating.begin',
     showAsFilter: true,
-    showAsResult: false,
+    showAsResult: true,
     filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
     key: 'dating_begin',
     value: 'dating.begin',
@@ -162,7 +162,7 @@ const mappings = [
   {
     display_value: 'dating.end',
     showAsFilter: true,
-    showAsResult: false,
+    showAsResult: true,
     sortable: true,
     filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
     key: 'dating_end',
@@ -393,6 +393,18 @@ const mappings = [
     value: 'sortingInfo.year',
   },
 
+  // Score
+  {
+    display_value: '_score',
+    showAsFilter: false,
+    showAsResult: false,
+    sortable: true,
+    filter_types: [],
+    key: 'score',
+    value: '_score',
+  },
+
+
   // Catalog Work Reference
   {
     display_value: 'catalogWorkReferences.description',
@@ -457,6 +469,10 @@ function isNestedFilter(filterkey) {
   return index > -1;
 }
 
+function getMappingByKey(key) {
+  return mappings.find((mapping) => mapping.key === key);
+}
+
 function getAllowedFilters() {
   return mappings.filter((mapping) => mapping.filter_types.length > 0);
 }
@@ -483,7 +499,6 @@ function getVisibleResults() {
   return ret;
 }
 
-
 function getDefaultSortFields() {
   return defaultSortFieldKeys.map(
     (defaultSortFieldKey) => mappings.find(mapping => mapping.key === defaultSortFieldKey),
@@ -502,6 +517,7 @@ module.exports = {
   isFilterInfosFilter,
   isNestedFilter,
   getAllowedFilters,
+  getMappingByKey,
   getSearchTermFields,
   getSortableFields,
   getVisibleFilters,

--- a/src/server/query-params-parser/index.js
+++ b/src/server/query-params-parser/index.js
@@ -35,6 +35,7 @@ function validateSortParams(req) {
 
   if (!filterParamsQuery.sort_by) {
     const defaultSortFields = getDefaultSortFields();
+
     defaultSortFields.forEach((defaultSortField) => {
       resultSortParams.push(new SortParam(defaultSortField.value, defautSortDirection));
     });


### PR DESCRIPTION
Ich habe die Sonderbehandlung im model für `dating_begin` und `dating_end` jetzt erstmal so beibehalten und das Ganze „Softranges” getauft.
Man könnte überlegen einen zusätzlichen Operator für die Softranges einzuführen. Also bspw. `slte` (SoftLowerThenEquals) oder `sgt` (SoftGreaterThen). Aber dann muss man bei der API Anfrage in der URL zwei Keys angeben. Weil, wenn man nach `dating_begin` filtert, ist auch gleichzeitig `dating_end` betroffen.  Aber ich weiß nicht ob das zu komplex ist. Was meinst du?