### PR TITLE
fix(searchterm): Move Operations to build Filterparams for searchterm…

### DIFF
--- a/src/entities/searchtermparam/index.js
+++ b/src/entities/searchtermparam/index.js
@@ -1,8 +1,0 @@
-class SearchtermParam {
-  constructor(fields, value) {
-    this.fields = fields;
-    this.value = value;
-  }
-}
-
-module.exports = SearchtermParam;

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -28,7 +28,7 @@ async function getItems(req, res) {
     from: req.api.from,
     language: req.query.language,
     size: req.api.size,
-    searchterm: req.api.searchtermParam,
+    searchterms: req.api.searchtermParams,
     showDataAll: req.query.show_data_all || false,
     sort: req.api.sortParams,
   };

--- a/src/server/es-engine/query-builder/index.js
+++ b/src/server/es-engine/query-builder/index.js
@@ -443,9 +443,7 @@ class Querybuilder {
                   should: this.shouldInnerMustWildcardQueryParams,
                 },
               }),
-
             must_not: this.mustNotQueryParams,
-            // should: this.shouldInnerMustWildcardQueryParams,
           },
         },
         aggs: this.termsAggregationParams,

--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -49,16 +49,18 @@ const mappings = [
     nestedPath: 'filterInfos.attribution',
     sortBy: 'filterInfos.attribution.order',
     filterInfos: true,
-    searchTermField: true,
   },
 
   // Zuschreibung (Array)
   {
-    display_value: 'involvedPersons',
-    filter_types: ['equals', 'notequals'],
+    display_value: 'involvedPersons.name',
+    filter_types: [],
     key: 'involved_persons',
-    value: 'involvedPersons',
+    value: 'involvedPersons.id',
+    nestedPath: 'involvedPersons',
     showAsResult: true,
+    searchTermField: true,
+
   },
 
   // Standort - Stadt
@@ -67,7 +69,7 @@ const mappings = [
     filter_types: ['equals', 'notequals', 'similar'],
     key: 'locations',
     value: 'locations.term',
-    showAsResult: false,
+    showAsResult: true,
     searchTermField: true,
   },
 
@@ -263,6 +265,7 @@ const mappings = [
     filter_types: ['equals', 'notequals', 'similar'],
     key: 'inventory_number',
     value: 'inventoryNumber.keyword',
+    searchTermField: true,
   },
 
   // Object name
@@ -277,12 +280,12 @@ const mappings = [
 
   // Eigentümer
   {
-    display_value: 'owner',
+    display_value: 'owner.keyword',
     showAsFilter: false,
     showAsResult: true,
     filter_types: [],
     key: 'owner',
-    value: 'owner',
+    value: 'owner.keyword',
     searchTermField: true,
   },
 
@@ -304,6 +307,28 @@ const mappings = [
     filter_types: [],
     key: 'print_process',
     value: 'classification.printProcess',
+  },
+
+  // Provenance
+  {
+    display_value: 'provenance.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'provenance',
+    value: 'provenance.keyword',
+    searchTermField: true,
+  },
+
+  // Signature
+  {
+    display_value: 'signature.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'signature',
+    value: 'signature.keyword',
+    searchTermField: true,
   },
 
   // Inhalt

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -133,10 +133,9 @@ async function getItems(req, params) {
       filter.display_value,
       filter.nestedPath || null,
     );
-    //queryBuilder.termsAggregation(aggregationParam);
+    queryBuilder.termsAggregation(aggregationParam);
   });
 
-  console.log(JSON.stringify(queryBuilder.query, null, 4));
 
   const result = await submitESSearch({ body: queryBuilder.query });
 

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -67,10 +67,10 @@ async function getItems(req, params) {
   queryBuilder.index(getIndexByLanguageKey(language));
   queryBuilder.paginate(params.from, params.size);
 
-  if (params.searchterm) {
-    params.searchterm.fields.forEach((field) => {
-      queryBuilder.shouldInnerMustWildcard(new FilterParam('searchterm', params.searchterm.value, null, null, field, null, null));
-      queryBuilder.highlight(new FilterParam('searchterm', params.searchterm.value, null, null, field, null, null));
+  if (params.searchterms) {
+    params.searchterms.forEach((searchtermFilterParam) => {
+      queryBuilder.shouldInnerMustWildcard(searchtermFilterParam);
+      queryBuilder.highlight(searchtermFilterParam);
     });
   }
 
@@ -133,8 +133,10 @@ async function getItems(req, params) {
       filter.display_value,
       filter.nestedPath || null,
     );
-    queryBuilder.termsAggregation(aggregationParam);
+    //queryBuilder.termsAggregation(aggregationParam);
   });
+
+  console.log(JSON.stringify(queryBuilder.query, null, 4));
 
   const result = await submitESSearch({ body: queryBuilder.query });
 

--- a/src/server/query-params-parser/index.js
+++ b/src/server/query-params-parser/index.js
@@ -13,19 +13,30 @@ const {
 
 const SortParam = require('../../entities/sortparam');
 const FilterParam = require('../../entities/filterparam');
-const SearchtermParam = require('../../entities/searchtermparam');
 
 // TODO: Aufrufe in einer Middleware zusammen
 function validateSearchTermParams(req) {
   const searchtermParam = req.query.searchterm;
+  const resultSearchtermParams = [];
 
   if (!searchtermParam) {
     return;
   }
 
-  const searchtermFields = getSearchTermFields().map(mapping => mapping.value);
-
-  req.api.searchtermParam = new SearchtermParam(searchtermFields, searchtermParam);
+  const searchtermFieldss = getSearchTermFields();
+  searchtermFieldss.forEach((searchtermField) => {
+    const filter = new FilterParam(
+      'searchterm',
+      searchtermParam,
+      'sim',
+      null,
+      searchtermField.display_value,
+      searchtermField.nestedPath || null,
+      null,
+    );
+    resultSearchtermParams.push(filter);
+  });
+  req.api.searchtermParams = resultSearchtermParams;
 }
 
 function validateSortParams(req) {


### PR DESCRIPTION
… filtering from model to query-params-parser

The reason for this is that the nestedPath must be taken into account when creating the filterparams. This information is still available in the query-params-parser, but not in the model.

The following fields are also included in the searchterm search now:
* involvedPersons.name
* locations.term
* owner
* provenance
* signature

