### PR TITLE
fix(query-params-parser): pass response to various function referencing a response variable

### DIFF
--- a/src/server/query-params-parser/index.js
+++ b/src/server/query-params-parser/index.js
@@ -39,7 +39,7 @@ function validateSearchTermParams(req) {
   req.api.searchtermParams = resultSearchtermParams;
 }
 
-function validateSortParams(req) {
+function validateSortParams(req, res) {
   const filterParamsQuery = req.query;
   const sortableFields = getSortableFields();
   const resultSortParams = [];
@@ -83,7 +83,7 @@ function validateSortParams(req) {
   req.api.sortParams = resultSortParams;
 }
 
-function validateFilterParams(req) {
+function validateFilterParams(req, res) {
   const filterParamsQuery = req.query;
   const filterParamsKeys = Object.keys(filterParamsQuery);
   const resultFilterParams = [];
@@ -161,8 +161,8 @@ function validatePaginationParams(req) {
 function validateParams(req, res, next) {
   req.api = {};
   validateSearchTermParams(req);
-  validateSortParams(req);
-  validateFilterParams(req);
+  validateSortParams(req, res);
+  validateFilterParams(req, res);
   validatePaginationParams(req);
   next();
 }


### PR DESCRIPTION
Einige Funktionen des query-params-parser haben eine `res`-Variable referenziert, obwohl keine solche Variable in dem Scope existiert hat.