### PR TITLE
Use archivals mappings when requested

### DIFF
--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -1,63 +1,67 @@
 const model = require('../models');
-const { entityTypes } = require('../mappings');
+const { Mappings } = require('../mappings');
 
-async function getSingleItem(req, res) {
-  const { id } = req.params;
-  if (!id) {
-    res.status(422).json({
-      error: true,
-      data: 'Missing required path parameter: id',
-    });
-    return;
-  }
-  const params = {
-    id,
-    language: req.query.language,
-  };
-  try {
-    const result = await model.getSingleItem(params);
-    res.json({ data: result });
-  } catch (err) {
-    console.log(err);
-    res.status(500).json({ success: false, error: err.message });
+function getSingleItem(mappings) {
+  return async (req, res) => {
+    const { id } = req.params;
+    if (!id) {
+      res.status(422).json({
+        error: true,
+        data: 'Missing required path parameter: id',
+      });
+      return;
+    }
+    const params = {
+      id,
+      language: req.query.language,
+    };
+    try {
+      const result = await model.getSingleItem(params, mappings);
+      res.json({ data: result });
+    } catch (err) {
+      console.log(err);
+      res.status(500).json({ success: false, error: err.message });
+    }
   }
 }
 
-async function getItems(req, res) {
-  let entityType = null;
-  const entityTypePath = req.path.slice(1);
-  if(entityTypePath.length > 0) {
-    if (entityTypes[entityTypePath]) {
-      entityType = entityTypePath;
-    } else {
-      res.status(404).json({
-        error: true,
-        data: 'Resource not found',
-      });
-    }  
-  }
+function getItems(mappings) {
+  return async (req, res) => {
+    let entityType = null;
+    const entityTypePath = req.path.slice(1);
+    if(entityTypePath.length > 0) {
+      if (Mappings.entityTypes[entityTypePath]) {
+        entityType = entityTypePath;
+      } else {
+        res.status(404).json({
+          error: true,
+          data: 'Resource not found',
+        });
+      }  
+    }
 
-  const params = {
-    entityType: entityType || null,
-    filters: req.api.filterParams,
-    from: req.api.from,
-    language: req.query.language,
-    size: req.api.size,
-    searchterms: req.api.searchtermParams,
-    showDataAll: req.query.show_data_all || false,
-    sort: req.api.sortParams,
+    const params = {
+      entityType: entityType || null,
+      filters: req.api.filterParams,
+      from: req.api.from,
+      language: req.query.language,
+      size: req.api.size,
+      searchterms: req.api.searchtermParams,
+      showDataAll: req.query.show_data_all || false,
+      sort: req.api.sortParams,
+    };
+
+    const { query } = req;
+
+    // }
+    try {
+      const result = await model.getItems(mappings, query, params);
+      res.json({ data: result });
+    } catch (err) {
+      console.log(err);
+      res.status(500).json({ success: false, error: err.message });
+    }
   };
-
-  const { query } = req;
-
-  // }
-  try {
-    const result = await model.getItems(query, params);
-    res.json({ data: result });
-  } catch (err) {
-    console.log(err);
-    res.status(500).json({ success: false, error: err.message });
-  }
 }
 
 module.exports = {

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -27,21 +27,8 @@ function getSingleItem(mappings) {
 
 function getItems(mappings) {
   return async (req, res) => {
-    let entityType = null;
-    const entityTypePath = req.path.slice(1);
-    if(entityTypePath.length > 0) {
-      if (Mappings.entityTypes[entityTypePath]) {
-        entityType = entityTypePath;
-      } else {
-        res.status(404).json({
-          error: true,
-          data: 'Resource not found',
-        });
-      }  
-    }
-
     const params = {
-      entityType: entityType || null,
+      entityTypes: mappings.getEntityTypes(),
       filters: req.api.filterParams,
       from: req.api.from,
       language: req.query.language,

--- a/src/server/es-engine/aggregator/index.js
+++ b/src/server/es-engine/aggregator/index.js
@@ -1,14 +1,10 @@
-const {
-  getVisibleResults,
-  isNestedFilter,
-  getSearchTermFields,
-} = require('../../mappings');
 
 class Aggregator {
   static aggregateESFilterBuckets(params) {
     const { setAsAvailable } = params;
     const { aggregations } = params;
     const { allFilters } = params;
+    const { mappings } = params;
 
     // TODO: Create recursive function
     // aggregate Filter
@@ -18,7 +14,7 @@ class Aggregator {
       let currentAggregation = aggregations[aggregationKey];
 
       // if nested field then take nested values
-      if (isNestedFilter(aggregationKey)) {
+      if (mappings.isNestedFilter(aggregationKey)) {
         currentAggregation = currentAggregation[aggregationKey];
       }
       const { buckets } = currentAggregation;
@@ -35,9 +31,9 @@ class Aggregator {
     return filters;
   }
 
-  static aggregateESResult(params, showDataAll = false) {
-    const visibleResults = getVisibleResults();
-    const searchTermFields = getSearchTermFields();
+  static aggregateESResult(params, mappings, showDataAll = false) {
+    const visibleResults = mappings.getVisibleResults();
+    const searchTermFields = mappings.getSearchTermFields();
 
     const response = params;
     const { hits } = response;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,7 +9,6 @@ const express = require('express');
 const routes = require('./routes');
 require('dotenv').config();
 const language = require('./language');
-const queryParamsParser = require('./query-params-parser');
 
 const app = express();
 const port = process.env.NODE_PORT || 8080;
@@ -46,7 +45,6 @@ function start() {
   return app.use(cors())
     .use(bodyParser.urlencoded({ extended: false }))
     .use(bodyParser.json())
-    .use(queryParamsParser.validateParams)
     .use(language)
     .use('/', routes)
     .use((_req, res) => res.status(404).json({ success: false, error: 'Route not found' }));

--- a/src/server/mappings/archivals/index.js
+++ b/src/server/mappings/archivals/index.js
@@ -26,119 +26,7 @@ const mappings = [
     Possible values: 'equals', 'notequals', 'range', 'notrange'
 
   }
-  // */
-  // // Zuschreibung
-  // {
-  //   display_value: 'involvedPersons.name.keyword',
-  //   key: 'attribution',
-  //   showAsFilter: true,
-  //   showAsResult: false,
-  //   value: 'involvedPersons.id.keyword',
-  //   filter_types: ['equals', 'notequals'],
-  //   filterInfos: true,
-  // },
-
-  // Zuschreibung
-  {
-    display_value: 'filterInfos.attribution.id',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals'],
-    key: 'attribution',
-    value: 'filterInfos.attribution.id',
-    nestedPath: 'filterInfos.attribution',
-    sortBy: 'filterInfos.attribution.order',
-    filterInfos: true,
-  },
-
-  // Involvierte Personen (Array)
-  {
-    display_value: 'involvedPersons',
-    filter_types: [],
-    key: 'involved_persons',
-    value: 'involvedPersons',
-    showAsResult: true,
-  },
-
-  // Involvierte Personen (Namen-Ebene)
-  {
-    display_value: 'involvedPersons.name',
-    filter_types: [],
-    key: 'involved_persons_name',
-    value: 'involvedPersons.id',
-    nestedPath: 'involvedPersons',
-    showAsResult: false,
-    searchTermField: true,
-  },
-
-
-  // Standort - Stadt
-  {
-    display_value: 'locations.term',
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'locations',
-    value: 'locations.term',
-    nestedPath: 'locations',
-    showAsResult: true,
-    searchTermField: true,
-  },
-
-  // Medium
-  {
-    display_value: 'medium',
-    filter_types: [],
-    key: 'medium',
-    value: 'medium',
-    showAsResult: true,
-    searchTermField: true,
-  },
-
-  // Sammlung / Standort
-  {
-    display_value: 'filterInfos.collection_repository.id',
-    key: 'collection_repository',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.collection_repository.id',
-    nestedPath: 'filterInfos.collection_repository',
-    filter_types: ['equals', 'notequals', 'similar'],
-    filterInfos: true,
-  },
-
-  // Untersuchungstechniken
-  {
-    display_value: 'filterInfos.examination_analysis.id',
-    key: 'examination_analysis',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.examination_analysis.id',
-    nestedPath: 'filterInfos.examination_analysis',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Katalog
-  {
-    display_value: 'filterInfos.catalog.id',
-    key: 'catalog',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.catalog.id',
-    nestedPath: 'filterInfos.catalog',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Die 100 besten Werke
-  {
-    display_value: 'isBestOf',
-    filter_types: ['equals', 'notequals'],
-    key: 'is_best_of',
-    showAsFilter: true,
-    value: 'isBestOf',
-    showAsResult: true,
-
-  },
+  */
 
   // Image
   {
@@ -191,72 +79,6 @@ const mappings = [
     filter_types: ['equals', 'notequals'],
   },
 
-  // Description
-  {
-    display_value: 'description',
-    showAsFilter: false,
-    showAsResult: false,
-    sortable: false,
-    filter_types: [],
-    key: 'description',
-    value: 'description',
-    searchTermField: true,
-  },
-
-  // Dimensionen
-  {
-    display_value: 'dimensions',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'dimensions',
-    value: 'dimensions',
-  },
-
-  // Form
-  {
-    display_value: 'filterInfos.form.id.keyword',
-    key: 'form',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.form.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Funktion
-  {
-    display_value: 'filterInfos.function.id.keyword',
-    key: 'function',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.function.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Bestandteile
-  {
-    display_value: 'filterInfos.component_parts.id.keyword',
-    key: 'component_parts',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.component_parts.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Technik
-  {
-    display_value: 'filterInfos.technique.id.keyword',
-    key: 'technique',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.technique.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
   // Abbildungen
   {
     display_value: 'images',
@@ -278,66 +100,14 @@ const mappings = [
     searchTermField: true,
   },
 
-  // Object name
-  {
-    display_value: 'objectName.keyword',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'object_name',
-    value: 'objectName.keyword',
-  },
-
   // Besitzer
   {
     display_value: 'repository.keyword',
-    showAsFilter: false,
+    showAsFilter: true,
     showAsResult: true,
-    filter_types: [],
+    filter_types: ['equals'],
     key: 'repository',
     value: 'repository.keyword',
-    searchTermField: true,
-  },
-
-  // Eigentümer
-  {
-    display_value: 'owner.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'owner',
-    value: 'owner.keyword',
-    searchTermField: true,
-  },
-
-  // Klassifizierung
-  {
-    display_value: 'classification.classification',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'classification',
-    value: 'classification.classification',
-  },
-
-  // Print Process
-  {
-    display_value: 'classification.printProcess',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'print_process',
-    value: 'classification.printProcess',
-  },
-
-  // Provenance
-  {
-    display_value: 'provenance',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'provenance',
-    value: 'provenance',
     searchTermField: true,
   },
 
@@ -350,18 +120,6 @@ const mappings = [
     key: 'signature',
     value: 'signature.keyword',
     searchTermField: true,
-  },
-
-  // Inhalt
-  {
-    display_value: 'filterInfos.subject.id',
-    key: 'subject',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.subject.id',
-    nestedPath: 'filterInfos.subject',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
   },
 
   // Titel
@@ -407,17 +165,19 @@ const mappings = [
   },
 
   // Sorting Number
-  {
-    display_value: 'sortingNumber.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    sortable: true,
-    filter_types: ['equals', 'notequals'],
-    key: 'sorting_number',
-    value: 'sortingNumber.keyword',
-  },
+  // To be reactivated on existing 'sortingNumber' field
+  // {
+  //   display_value: 'sortingNumber.keyword',
+  //   showAsFilter: false,
+  //   showAsResult: true,
+  //   sortable: true,
+  //   filter_types: ['equals', 'notequals'],
+  //   key: 'sorting_number',
+  //   value: 'sortingNumber.keyword',
+  // },
 
   // Search sortingnumber
+  // TODO: 'searchSortingNumber' field does not exist yet, but mapping is currently needed because of it beeing used as default sorting field
   {
     display_value: 'searchSortingNumber.keyword',
     showAsFilter: false,
@@ -437,53 +197,6 @@ const mappings = [
     filter_types: [],
     key: 'score',
     value: '_score',
-  },
-
-
-  // Catalog Work Reference
-  {
-    display_value: 'catalogWorkReferences.description',
-    showAsFilter: true,
-    showAsResult: false,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'catalog_name',
-    value: 'catalogWorkReferences.description',
-    nestedPath: 'catalogWorkReferences',
-  },
-
-  // Catalog Work Reference Number
-  {
-    display_value: 'catalogWorkReferences.referenceNumber',
-    showAsFilter: true,
-    showAsResult: false,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'catalog_work_reference_number',
-    value: 'catalogWorkReferences.referenceNumber',
-    nestedPath: 'catalogWorkReferences',
-  },
-
-  // Additional text information
-  {
-    display_value: 'additionalTextInformation.text',
-    showAsFilter: false,
-    showAsResult: false,
-    filter_types: [],
-    key: 'additional_text_information_text',
-    value: 'additionalTextInformation.text',
-    nestedPath: 'additionalTextInformation',
-    searchTermField: true,
-  },
-
-  // Restoration survey tests text
-  {
-    display_value: 'restorationSurveys.tests.text',
-    showAsFilter: false,
-    showAsResult: false,
-    filter_types: [],
-    key: 'restoration_surveys_tests_text',
-    value: 'restorationSurveys.tests.text',
-    nestedPath: 'restorationSurveys.tests',
-    searchTermField: true,
   },
 ];
 

--- a/src/server/mappings/archivals/index.js
+++ b/src/server/mappings/archivals/index.js
@@ -100,15 +100,26 @@ const mappings = [
     searchTermField: true,
   },
 
-  // Besitzer
+  // Institutionen (rein für die Suche)
+  {
+    display_value: 'repository.keyword',
+    showAsFilter: false,
+    showAsResult: false,
+    filter_types: [],
+    key: 'repository',
+    value: 'repository.keyword',
+    searchTermField: true,
+  },
+
+  // Institutionen (mit sauberer ID für klare Filterung)
   {
     display_value: 'repository.keyword',
     showAsFilter: true,
     showAsResult: true,
     filter_types: ['equals'],
-    key: 'repository',
-    value: 'repository.keyword',
-    searchTermField: true,
+    key: 'institution',
+    value: 'repositoryId.keyword',
+    searchTermField: false,
   },
 
   // Signature

--- a/src/server/mappings/archivals/index.js
+++ b/src/server/mappings/archivals/index.js
@@ -200,6 +200,9 @@ const mappings = [
   },
 ];
 
+const entityTypes = ['ARCHIVAL'];
+
 module.exports = {
   mappings,
+  entityTypes,
 };

--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -1,596 +1,104 @@
-let mappings = [
 
-  /*
-  Documentation of the fields from the mappings
-  {
-    display_value: <string>
-    Value to be displayed in the frontend,
+const MappingType = {
+  WORKS: 'works',
+  ARCHIVALS: 'archivals',
+};
 
-    key: <string>
-    Value under which the filters are grouped
+class Mappings {
+  static specialParams = ['size', 'from', 'sort_by', 'language', 'searchterm', 'show_data_all'];
 
-    showAsResult: <boolean>
-    Indicates if this field will be outputted as result item
+  static availableFilterTypes = {
+    eq: 'equals',
+    neq: 'notequals',
+    meq: 'multiequals',
+    gt: 'range',
+    gte: 'range',
+    lt: 'range',
+    lte: 'range',
+    ngt: 'notrange',
+    ngte: 'notrange',
+    nlt: 'notrange',
+    nlte: 'notrange',
+    sim: 'similar',
+  };
 
-    showAsFilter: <boolean>
-    Indicates if this field will be outputted as filter
+  static defaultFilterType = 'eq';
+  static defaultSortFieldKeys = ['search_sorting_number'];
+  static defaultResponseSize = 100;
 
-    searchTermField: <boolean>
-    Indicates if this field is considered in filtering by searchterm
+  static availableSortTypes = {
+    asc: 'ascending',
+    desc: 'descending',
+  };
 
-    value: <string>
-    Value that can be filtered by (This value is language independent)
-
-    filter_types: Array<string>
-    For this group allowed filter types.
-    Possible values: 'equals', 'notequals', 'range', 'notrange'
-
+  static entityTypes = {
+    graphics: 'GRAPHIC',
+    paintings: 'PAINTING',
+    archivals: 'ARCHIVAL',
   }
-  // */
-  // // Zuschreibung
-  // {
-  //   display_value: 'involvedPersons.name.keyword',
-  //   key: 'attribution',
-  //   showAsFilter: true,
-  //   showAsResult: false,
-  //   value: 'involvedPersons.id.keyword',
-  //   filter_types: ['equals', 'notequals'],
-  //   filterInfos: true,
-  // },
 
-  // Zuschreibung
-  {
-    display_value: 'filterInfos.attribution.id',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals'],
-    key: 'attribution',
-    value: 'filterInfos.attribution.id',
-    nestedPath: 'filterInfos.attribution',
-    sortBy: 'filterInfos.attribution.order',
-    filterInfos: true,
-  },
+  static defautSortDirection = 'asc';
 
-  // Involvierte Personen (Array)
-  {
-    display_value: 'involvedPersons',
-    filter_types: [],
-    key: 'involved_persons',
-    value: 'involvedPersons',
-    showAsResult: true,
-  },
+  constructor(type) {
+    if (!(Object.values(MappingType).includes(type))) {
+      throw new Error(`Unsupported mapping type: ${type}`);
+    }
 
-  // Involvierte Personen (Namen-Ebene)
-  {
-    display_value: 'involvedPersons.name',
-    filter_types: [],
-    key: 'involved_persons_name',
-    value: 'involvedPersons.id',
-    nestedPath: 'involvedPersons',
-    showAsResult: false,
-    searchTermField: true,
-  },
+    const { mappings } = require(`./${type}/index.js`);
+    this.mappings = mappings;
+  }
 
+  isFilterInfosFilter(filterKey) {
+    const index = this.mappings.findIndex((mapping) => mapping.key === filterKey
+      && mapping.filterInfos
+      && mapping.filterInfos === true);
+    return index > -1;
+  }
 
-  // Standort - Stadt
-  {
-    display_value: 'locations.term',
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'locations',
-    value: 'locations.term',
-    nestedPath: 'locations',
-    showAsResult: true,
-    searchTermField: true,
-  },
+  isNestedFilter(filterkey) {
+    const index = this.mappings.findIndex((mapping) => mapping.key === filterkey
+      && mapping.nestedPath);
+    return index > -1;
+  }
 
-  // Medium
-  {
-    display_value: 'medium',
-    filter_types: [],
-    key: 'medium',
-    value: 'medium',
-    showAsResult: true,
-    searchTermField: true,
-  },
+  getMappingByKey(key) {
+    return this.mappings.find((mapping) => mapping.key === key);
+  }
 
-  // Sammlung / Standort
-  {
-    display_value: 'filterInfos.collection_repository.id',
-    key: 'collection_repository',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.collection_repository.id',
-    nestedPath: 'filterInfos.collection_repository',
-    filter_types: ['equals', 'notequals', 'similar'],
-    filterInfos: true,
-  },
+  getAllowedFilters() {
+    return this.mappings.filter((mapping) => mapping.filter_types.length > 0);
+  }
 
-  // Untersuchungstechniken
-  {
-    display_value: 'filterInfos.examination_analysis.id',
-    key: 'examination_analysis',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.examination_analysis.id',
-    nestedPath: 'filterInfos.examination_analysis',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
+  getSortableFields() {
+    return this.mappings.filter((mapping) => mapping.sortable === true);
+  }
 
-  // Katalog
-  {
-    display_value: 'filterInfos.catalog.id',
-    key: 'catalog',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.catalog.id',
-    nestedPath: 'filterInfos.catalog',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
+  getVisibleFilters() {
+    return this.mappings.filter((mapping) => mapping.showAsFilter === true);
+  }
 
-  // Die 100 besten Werke
-  {
-    display_value: 'isBestOf',
-    filter_types: ['equals', 'notequals'],
-    key: 'is_best_of',
-    showAsFilter: true,
-    value: 'isBestOf',
-    showAsResult: true,
+  getSearchTermFields() {
+    return this.mappings.filter((mapping) => mapping.searchTermField === true);
+  }
 
-  },
+  getVisibleResults() {
+    const filteredMappings = this.mappings.filter((mapping) => mapping.showAsResult === true);
+    const ret = filteredMappings.map((mapping) => {
+      const currentMapping = { ...mapping };
+      currentMapping.display_value = mapping.display_value.replace(/\.keyword$/, '');
+      return currentMapping;
+    });
+    return ret;
+  }
 
-  // Image
-  {
-    display_value: 'metadata.imgSrc.keyword',
-    showAsResult: true,
-    filter_types: [],
-    key: 'img_src',
-    value: 'metadata.imgSrc.keyword',
-  },
-
-  // Datierung
-  {
-    display_value: 'metadata.date',
-    showAsFilter: false,
-    showAsResult: true,
-    sortable: true,
-    filter_types: [],
-    key: 'dating',
-    value: 'metadata.date.keyword',
-  },
-
-  // Datierung Beginn
-  {
-    display_value: 'dating.begin',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
-    key: 'dating_begin',
-    value: 'dating.begin',
-  },
-
-  // Datierung Ende
-  {
-    display_value: 'dating.end',
-    showAsFilter: true,
-    showAsResult: true,
-    sortable: true,
-    filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
-    key: 'dating_end',
-    value: 'dating.end',
-  },
-
-  // Entitäts typ
-  {
-    display_value: 'metadata.entityType.keyword',
-    key: 'entity_type',
-    showAsFilter: true,
-    showAsResult: true,
-    value: 'metadata.entityType.keyword',
-    filter_types: ['equals', 'notequals'],
-  },
-
-  // Description
-  {
-    display_value: 'description',
-    showAsFilter: false,
-    showAsResult: false,
-    sortable: false,
-    filter_types: [],
-    key: 'description',
-    value: 'description',
-    searchTermField: true,
-  },
-
-  // Dimensionen
-  {
-    display_value: 'dimensions',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'dimensions',
-    value: 'dimensions',
-  },
-
-  // Form
-  {
-    display_value: 'filterInfos.form.id.keyword',
-    key: 'form',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.form.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Funktion
-  {
-    display_value: 'filterInfos.function.id.keyword',
-    key: 'function',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.function.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Bestandteile
-  {
-    display_value: 'filterInfos.component_parts.id.keyword',
-    key: 'component_parts',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.component_parts.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Technik
-  {
-    display_value: 'filterInfos.technique.id.keyword',
-    key: 'technique',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.technique.id.keyword',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Abbildungen
-  {
-    display_value: 'images',
-    showAsFilter: false,
-    showAsResult: false,
-    filter_types: [],
-    key: 'images',
-    value: 'images',
-  },
-
-  // Inventarnummer
-  {
-    display_value: 'inventoryNumber.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'inventory_number',
-    value: 'inventoryNumber.keyword',
-    searchTermField: true,
-  },
-
-  // Object name
-  {
-    display_value: 'objectName.keyword',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'object_name',
-    value: 'objectName.keyword',
-  },
-
-  // Besitzer
-  {
-    display_value: 'repository.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'repository',
-    value: 'repository.keyword',
-    searchTermField: true,
-  },
-
-  // Eigentümer
-  {
-    display_value: 'owner.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'owner',
-    value: 'owner.keyword',
-    searchTermField: true,
-  },
-
-  // Klassifizierung
-  {
-    display_value: 'classification.classification',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'classification',
-    value: 'classification.classification',
-  },
-
-  // Print Process
-  {
-    display_value: 'classification.printProcess',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'print_process',
-    value: 'classification.printProcess',
-  },
-
-  // Provenance
-  {
-    display_value: 'provenance',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'provenance',
-    value: 'provenance',
-    searchTermField: true,
-  },
-
-  // Signature
-  {
-    display_value: 'signature.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'signature',
-    value: 'signature.keyword',
-    searchTermField: true,
-  },
-
-  // Inhalt
-  {
-    display_value: 'filterInfos.subject.id',
-    key: 'subject',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'filterInfos.subject.id',
-    nestedPath: 'filterInfos.subject',
-    filter_types: ['equals', 'notequals'],
-    filterInfos: true,
-  },
-
-  // Titel
-  {
-    display_value: 'metadata.title.keyword',
-    showAsFilter: true,
-    showAsResult: true,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'title',
-    value: 'metadata.title.keyword',
-    searchTermField: true,
-  },
-
-  // Dimension - Breite
-  {
-    display_value: 'images.overall.infos.maxDimensions.width',
-    key: 'size_width',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'images.overall.infos.maxDimensions.width',
-    filter_types: ['equals', 'notequals', 'range', 'notrange'],
-  },
-
-  // Dimension - Höhe
-  {
-    display_value: 'images.overall.infos.maxDimensions.height',
-    key: 'size_height',
-    showAsFilter: true,
-    showAsResult: false,
-    value: 'images.overall.infos.maxDimensions.height',
-    filter_types: ['equals', 'notequals', 'range', 'notrange'],
-  },
-
-  // Untertitel
-  {
-    display_value: 'metadata.subtitle',
-    showAsFilter: false,
-    showAsResult: true,
-    filter_types: [],
-    key: 'subtitle',
-    value: 'metadata.subtitle',
-    searchTermField: true,
-  },
-
-  // Sorting Number
-  {
-    display_value: 'sortingNumber.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    sortable: true,
-    filter_types: ['equals', 'notequals'],
-    key: 'sorting_number',
-    value: 'sortingNumber.keyword',
-  },
-
-  // Search sortingnumber
-  {
-    display_value: 'searchSortingNumber.keyword',
-    showAsFilter: false,
-    showAsResult: true,
-    sortable: true,
-    filter_types: [],
-    key: 'search_sorting_number',
-    value: 'searchSortingNumber.keyword',
-  },
-
-  // Score
-  {
-    display_value: '_score',
-    showAsFilter: false,
-    showAsResult: false,
-    sortable: true,
-    filter_types: [],
-    key: 'score',
-    value: '_score',
-  },
-
-
-  // Catalog Work Reference
-  {
-    display_value: 'catalogWorkReferences.description',
-    showAsFilter: true,
-    showAsResult: false,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'catalog_name',
-    value: 'catalogWorkReferences.description',
-    nestedPath: 'catalogWorkReferences',
-  },
-
-  // Catalog Work Reference Number
-  {
-    display_value: 'catalogWorkReferences.referenceNumber',
-    showAsFilter: true,
-    showAsResult: false,
-    filter_types: ['equals', 'notequals', 'similar'],
-    key: 'catalog_work_reference_number',
-    value: 'catalogWorkReferences.referenceNumber',
-    nestedPath: 'catalogWorkReferences',
-  },
-
-  // Additional text information
-  {
-    display_value: 'additionalTextInformation.text',
-    showAsFilter: false,
-    showAsResult: false,
-    filter_types: [],
-    key: 'additional_text_information_text',
-    value: 'additionalTextInformation.text',
-    nestedPath: 'additionalTextInformation',
-    searchTermField: true,
-  },
-
-  // Restoration survey tests text
-  {
-    display_value: 'restorationSurveys.tests.text',
-    showAsFilter: false,
-    showAsResult: false,
-    filter_types: [],
-    key: 'restoration_surveys_tests_text',
-    value: 'restorationSurveys.tests.text',
-    nestedPath: 'restorationSurveys.tests',
-    searchTermField: true,
-  },
-];
-
-const specialParams = ['size', 'from', 'sort_by', 'language', 'searchterm', 'show_data_all'];
-
-const availableFilterTypes = {
-  eq: 'equals',
-  neq: 'notequals',
-  meq: 'multiequals',
-  gt: 'range',
-  gte: 'range',
-  lt: 'range',
-  lte: 'range',
-  ngt: 'notrange',
-  ngte: 'notrange',
-  nlt: 'notrange',
-  nlte: 'notrange',
-  sim: 'similar',
-};
-
-const defaultFilterType = 'eq';
-const defaultSortFieldKeys = ['search_sorting_number'];
-const defaultResponseSize = 100;
-
-const availableSortTypes = {
-  asc: 'ascending',
-  desc: 'descending',
-};
-
-const entityTypes = {
-  graphics: 'GRAPHIC',
-  paintings: 'PAINTING',
-  archivals: 'ARCHIVAL',
-}
-
-const defautSortDirection = 'asc';
-
-function isFilterInfosFilter(filterKey) {
-  const index = mappings.findIndex((mapping) => mapping.key === filterKey
-    && mapping.filterInfos
-    && mapping.filterInfos === true);
-  return index > -1;
-}
-
-function isNestedFilter(filterkey) {
-  const index = mappings.findIndex((mapping) => mapping.key === filterkey
-    && mapping.nestedPath);
-  return index > -1;
-}
-
-function getMappingByKey(key) {
-  return mappings.find((mapping) => mapping.key === key);
-}
-
-function getAllowedFilters() {
-  return mappings.filter((mapping) => mapping.filter_types.length > 0);
-}
-
-function getSortableFields() {
-  return mappings.filter((mapping) => mapping.sortable === true);
-}
-
-function getVisibleFilters() {
-  return mappings.filter((mapping) => mapping.showAsFilter === true);
-}
-
-function getSearchTermFields() {
-  return mappings.filter((mapping) => mapping.searchTermField === true);
-}
-
-function getVisibleResults() {
-  const filteredMappings = mappings.filter((mapping) => mapping.showAsResult === true);
-  const ret = filteredMappings.map((mapping) => {
-    const currentMapping = { ...mapping };
-    currentMapping.display_value = mapping.display_value.replace(/\.keyword$/, '');
-    return currentMapping;
-  });
-  return ret;
-}
-
-function getDefaultSortFields() {
-  return defaultSortFieldKeys.map(
-    (defaultSortFieldKey) => mappings.find(mapping => mapping.key === defaultSortFieldKey),
-  );
-}
-
-function setMappings(newMappings) {
-  mappings = newMappings;
+  getDefaultSortFields() {
+    return Mappings.defaultSortFieldKeys.map(
+      (defaultSortFieldKey) => this.mappings.find(mapping => mapping.key === defaultSortFieldKey),
+    );
+  }
 }
 
 module.exports = {
-  availableFilterTypes,
-  availableSortTypes,
-  defaultFilterType,
-  defaultResponseSize,
-  entityTypes,
-  getDefaultSortFields,
-  defautSortDirection,
-  mappings,
-  specialParams,
-  isFilterInfosFilter,
-  isNestedFilter,
-  getAllowedFilters,
-  getMappingByKey,
-  getSearchTermFields,
-  getSortableFields,
-  getVisibleFilters,
-  getVisibleResults,
-  setMappings
+  Mappings,
+  MappingType,
 };

--- a/src/server/mappings/index.js
+++ b/src/server/mappings/index.js
@@ -31,12 +31,6 @@ class Mappings {
     desc: 'descending',
   };
 
-  static entityTypes = {
-    graphics: 'GRAPHIC',
-    paintings: 'PAINTING',
-    archivals: 'ARCHIVAL',
-  }
-
   static defautSortDirection = 'asc';
 
   constructor(type) {
@@ -44,8 +38,9 @@ class Mappings {
       throw new Error(`Unsupported mapping type: ${type}`);
     }
 
-    const { mappings } = require(`./${type}/index.js`);
+    const { mappings, entityTypes } = require(`./${type}/index.js`);
     this.mappings = mappings;
+    this.entityTypes = entityTypes;
   }
 
   isFilterInfosFilter(filterKey) {
@@ -95,6 +90,10 @@ class Mappings {
     return Mappings.defaultSortFieldKeys.map(
       (defaultSortFieldKey) => this.mappings.find(mapping => mapping.key === defaultSortFieldKey),
     );
+  }
+
+  getEntityTypes() {
+    return this.entityTypes;
   }
 }
 

--- a/src/server/mappings/works/index.js
+++ b/src/server/mappings/works/index.js
@@ -487,6 +487,9 @@ const mappings = [
   },
 ];
 
+const entityTypes = ['PAINTING', 'GRAPHIC'];
+
 module.exports = {
   mappings,
+  entityTypes,
 };

--- a/src/server/mappings/works/index.js
+++ b/src/server/mappings/works/index.js
@@ -1,0 +1,492 @@
+const mappings = [
+
+  /*
+  Documentation of the fields from the mappings
+  {
+    display_value: <string>
+    Value to be displayed in the frontend,
+
+    key: <string>
+    Value under which the filters are grouped
+
+    showAsResult: <boolean>
+    Indicates if this field will be outputted as result item
+
+    showAsFilter: <boolean>
+    Indicates if this field will be outputted as filter
+
+    searchTermField: <boolean>
+    Indicates if this field is considered in filtering by searchterm
+
+    value: <string>
+    Value that can be filtered by (This value is language independent)
+
+    filter_types: Array<string>
+    For this group allowed filter types.
+    Possible values: 'equals', 'notequals', 'range', 'notrange'
+
+  }
+  // */
+  // // Zuschreibung
+  // {
+  //   display_value: 'involvedPersons.name.keyword',
+  //   key: 'attribution',
+  //   showAsFilter: true,
+  //   showAsResult: false,
+  //   value: 'involvedPersons.id.keyword',
+  //   filter_types: ['equals', 'notequals'],
+  //   filterInfos: true,
+  // },
+
+  // Zuschreibung
+  {
+    display_value: 'filterInfos.attribution.id',
+    showAsFilter: true,
+    showAsResult: true,
+    filter_types: ['equals', 'notequals'],
+    key: 'attribution',
+    value: 'filterInfos.attribution.id',
+    nestedPath: 'filterInfos.attribution',
+    sortBy: 'filterInfos.attribution.order',
+    filterInfos: true,
+  },
+
+  // Involvierte Personen (Array)
+  {
+    display_value: 'involvedPersons',
+    filter_types: [],
+    key: 'involved_persons',
+    value: 'involvedPersons',
+    showAsResult: true,
+  },
+
+  // Involvierte Personen (Namen-Ebene)
+  {
+    display_value: 'involvedPersons.name',
+    filter_types: [],
+    key: 'involved_persons_name',
+    value: 'involvedPersons.id',
+    nestedPath: 'involvedPersons',
+    showAsResult: false,
+    searchTermField: true,
+  },
+
+
+  // Standort - Stadt
+  {
+    display_value: 'locations.term',
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'locations',
+    value: 'locations.term',
+    nestedPath: 'locations',
+    showAsResult: true,
+    searchTermField: true,
+  },
+
+  // Medium
+  {
+    display_value: 'medium',
+    filter_types: [],
+    key: 'medium',
+    value: 'medium',
+    showAsResult: true,
+    searchTermField: true,
+  },
+
+  // Sammlung / Standort
+  {
+    display_value: 'filterInfos.collection_repository.id',
+    key: 'collection_repository',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.collection_repository.id',
+    nestedPath: 'filterInfos.collection_repository',
+    filter_types: ['equals', 'notequals', 'similar'],
+    filterInfos: true,
+  },
+
+  // Untersuchungstechniken
+  {
+    display_value: 'filterInfos.examination_analysis.id',
+    key: 'examination_analysis',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.examination_analysis.id',
+    nestedPath: 'filterInfos.examination_analysis',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Katalog
+  {
+    display_value: 'filterInfos.catalog.id',
+    key: 'catalog',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.catalog.id',
+    nestedPath: 'filterInfos.catalog',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Die 100 besten Werke
+  {
+    display_value: 'isBestOf',
+    filter_types: ['equals', 'notequals'],
+    key: 'is_best_of',
+    showAsFilter: true,
+    value: 'isBestOf',
+    showAsResult: true,
+
+  },
+
+  // Image
+  {
+    display_value: 'metadata.imgSrc.keyword',
+    showAsResult: true,
+    filter_types: [],
+    key: 'img_src',
+    value: 'metadata.imgSrc.keyword',
+  },
+
+  // Datierung
+  {
+    display_value: 'metadata.date',
+    showAsFilter: false,
+    showAsResult: true,
+    sortable: true,
+    filter_types: [],
+    key: 'dating',
+    value: 'metadata.date.keyword',
+  },
+
+  // Datierung Beginn
+  {
+    display_value: 'dating.begin',
+    showAsFilter: true,
+    showAsResult: true,
+    filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
+    key: 'dating_begin',
+    value: 'dating.begin',
+  },
+
+  // Datierung Ende
+  {
+    display_value: 'dating.end',
+    showAsFilter: true,
+    showAsResult: true,
+    sortable: true,
+    filter_types: ['equals', 'notequals', 'range', 'notrange', 'multiequals'],
+    key: 'dating_end',
+    value: 'dating.end',
+  },
+
+  // Entitäts typ
+  {
+    display_value: 'metadata.entityType.keyword',
+    key: 'entity_type',
+    showAsFilter: true,
+    showAsResult: true,
+    value: 'metadata.entityType.keyword',
+    filter_types: ['equals', 'notequals'],
+  },
+
+  // Description
+  {
+    display_value: 'description',
+    showAsFilter: false,
+    showAsResult: false,
+    sortable: false,
+    filter_types: [],
+    key: 'description',
+    value: 'description',
+    searchTermField: true,
+  },
+
+  // Dimensionen
+  {
+    display_value: 'dimensions',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'dimensions',
+    value: 'dimensions',
+  },
+
+  // Form
+  {
+    display_value: 'filterInfos.form.id.keyword',
+    key: 'form',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.form.id.keyword',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Funktion
+  {
+    display_value: 'filterInfos.function.id.keyword',
+    key: 'function',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.function.id.keyword',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Bestandteile
+  {
+    display_value: 'filterInfos.component_parts.id.keyword',
+    key: 'component_parts',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.component_parts.id.keyword',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Technik
+  {
+    display_value: 'filterInfos.technique.id.keyword',
+    key: 'technique',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.technique.id.keyword',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Abbildungen
+  {
+    display_value: 'images',
+    showAsFilter: false,
+    showAsResult: false,
+    filter_types: [],
+    key: 'images',
+    value: 'images',
+  },
+
+  // Inventarnummer
+  {
+    display_value: 'inventoryNumber.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'inventory_number',
+    value: 'inventoryNumber.keyword',
+    searchTermField: true,
+  },
+
+  // Object name
+  {
+    display_value: 'objectName.keyword',
+    showAsFilter: true,
+    showAsResult: true,
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'object_name',
+    value: 'objectName.keyword',
+  },
+
+  // Besitzer
+  {
+    display_value: 'repository.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'repository',
+    value: 'repository.keyword',
+    searchTermField: true,
+  },
+
+  // Eigentümer
+  {
+    display_value: 'owner.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'owner',
+    value: 'owner.keyword',
+    searchTermField: true,
+  },
+
+  // Klassifizierung
+  {
+    display_value: 'classification.classification',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'classification',
+    value: 'classification.classification',
+  },
+
+  // Print Process
+  {
+    display_value: 'classification.printProcess',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'print_process',
+    value: 'classification.printProcess',
+  },
+
+  // Provenance
+  {
+    display_value: 'provenance',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'provenance',
+    value: 'provenance',
+    searchTermField: true,
+  },
+
+  // Signature
+  {
+    display_value: 'signature.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'signature',
+    value: 'signature.keyword',
+    searchTermField: true,
+  },
+
+  // Inhalt
+  {
+    display_value: 'filterInfos.subject.id',
+    key: 'subject',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'filterInfos.subject.id',
+    nestedPath: 'filterInfos.subject',
+    filter_types: ['equals', 'notequals'],
+    filterInfos: true,
+  },
+
+  // Titel
+  {
+    display_value: 'metadata.title.keyword',
+    showAsFilter: true,
+    showAsResult: true,
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'title',
+    value: 'metadata.title.keyword',
+    searchTermField: true,
+  },
+
+  // Dimension - Breite
+  {
+    display_value: 'images.overall.infos.maxDimensions.width',
+    key: 'size_width',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'images.overall.infos.maxDimensions.width',
+    filter_types: ['equals', 'notequals', 'range', 'notrange'],
+  },
+
+  // Dimension - Höhe
+  {
+    display_value: 'images.overall.infos.maxDimensions.height',
+    key: 'size_height',
+    showAsFilter: true,
+    showAsResult: false,
+    value: 'images.overall.infos.maxDimensions.height',
+    filter_types: ['equals', 'notequals', 'range', 'notrange'],
+  },
+
+  // Untertitel
+  {
+    display_value: 'metadata.subtitle',
+    showAsFilter: false,
+    showAsResult: true,
+    filter_types: [],
+    key: 'subtitle',
+    value: 'metadata.subtitle',
+    searchTermField: true,
+  },
+
+  // Sorting Number
+  {
+    display_value: 'sortingNumber.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    sortable: true,
+    filter_types: ['equals', 'notequals'],
+    key: 'sorting_number',
+    value: 'sortingNumber.keyword',
+  },
+
+  // Search sortingnumber
+  {
+    display_value: 'searchSortingNumber.keyword',
+    showAsFilter: false,
+    showAsResult: true,
+    sortable: true,
+    filter_types: [],
+    key: 'search_sorting_number',
+    value: 'searchSortingNumber.keyword',
+  },
+
+  // Score
+  {
+    display_value: '_score',
+    showAsFilter: false,
+    showAsResult: false,
+    sortable: true,
+    filter_types: [],
+    key: 'score',
+    value: '_score',
+  },
+
+
+  // Catalog Work Reference
+  {
+    display_value: 'catalogWorkReferences.description',
+    showAsFilter: true,
+    showAsResult: false,
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'catalog_name',
+    value: 'catalogWorkReferences.description',
+    nestedPath: 'catalogWorkReferences',
+  },
+
+  // Catalog Work Reference Number
+  {
+    display_value: 'catalogWorkReferences.referenceNumber',
+    showAsFilter: true,
+    showAsResult: false,
+    filter_types: ['equals', 'notequals', 'similar'],
+    key: 'catalog_work_reference_number',
+    value: 'catalogWorkReferences.referenceNumber',
+    nestedPath: 'catalogWorkReferences',
+  },
+
+  // Additional text information
+  {
+    display_value: 'additionalTextInformation.text',
+    showAsFilter: false,
+    showAsResult: false,
+    filter_types: [],
+    key: 'additional_text_information_text',
+    value: 'additionalTextInformation.text',
+    nestedPath: 'additionalTextInformation',
+    searchTermField: true,
+  },
+
+  // Restoration survey tests text
+  {
+    display_value: 'restorationSurveys.tests.text',
+    showAsFilter: false,
+    showAsResult: false,
+    filter_types: [],
+    key: 'restoration_surveys_tests_text',
+    value: 'restorationSurveys.tests.text',
+    nestedPath: 'restorationSurveys.tests',
+    searchTermField: true,
+  },
+];
+
+module.exports = {
+  mappings,
+};

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -57,12 +57,12 @@ async function getItems(mappings, req, params) {
 
   const queryBuilder = new Querybuilder();
 
-  // Subresource was setted
-  if (params.entityType) {
+  // Restrict items to certain entity types
+  if (params.entityTypes) {
     const entityTypeMapping = mappings.getMappingByKey('entity_type');
     const entityFilter = {
       key: 'entity_type',
-      values: [Mappings.entityTypes[params.entityType]],
+      values: params.entityTypes,
       valueField: entityTypeMapping.value,
       operator: 'eq',
     }

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -57,18 +57,19 @@ async function getItems(mappings, req, params) {
 
   const queryBuilder = new Querybuilder();
 
-  // Restrict items to certain entity types
-  if (params.entityTypes) {
-    const entityTypeMapping = mappings.getMappingByKey('entity_type');
-    const entityFilter = {
-      key: 'entity_type',
-      values: params.entityTypes,
-      valueField: entityTypeMapping.value,
-      operator: 'eq',
-    }
-
-    queryBuilder.must(entityFilter);
+  const entityTypeMapping = mappings.getMappingByKey('entity_type');
+  const entityFilter = {
+    key: 'entity_type',
+    values: params.entityTypes,
+    valueField: entityTypeMapping.value,
+    operator: 'eq',
   }
+
+  // Restrict filter aggregation to certain entity types
+  queryBuilder.filterAggregation(entityFilter);
+
+  // Restrict items to certain entity types
+  queryBuilder.must(entityFilter);
 
   const { language, showDataAll } = params;
 

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -1,30 +1,22 @@
 /* eslint-disable no-underscore-dangle */
 const path = require('path');
 const fs = require('fs');
+
 const AggregationParam = require('../../entities/aggregationparam');
 const FilterParam = require('../../entities/filterparam');
 const SortParam = require('../../entities/sortparam');
+const { esclient, getIndexByLanguageKey } = require('../../elastic');
+const { Mappings } = require('../mappings');
+const Querybuilder = require('../es-engine/query-builder');
+const Aggregator = require('../es-engine/aggregator');
 
 const assetsDirectoryPath = path.join(__dirname, '..', 'assets');
 const translations = require('../translations');
-
-const { esclient, getIndexByLanguageKey } = require(path.join(__dirname, '..', '..', 'elastic'));
-const {
-  entityTypes,
-  isFilterInfosFilter,
-  getVisibleFilters,
-  getMappingByKey,
-  setMappings,
-} = require('../mappings');
 
 const filterInfos = {
   de: JSON.parse(fs.readFileSync(path.join(assetsDirectoryPath, 'filters', 'cda-filters.de.json'))),
   en: JSON.parse(fs.readFileSync(path.join(assetsDirectoryPath, 'filters', 'cda-filters.en.json'))),
 };
-const Querybuilder = require(path.join(__dirname, '..', 'es-engine', 'query-builder'));
-const Aggregator = require(path.join(__dirname, '..', 'es-engine', 'aggregator'));
-
-const visibleFilters = getVisibleFilters();
 
 async function submitESSearch(params) {
   try {
@@ -35,7 +27,7 @@ async function submitESSearch(params) {
   }
 }
 
-async function getSingleItem(params) {
+async function getSingleItem(mappings, params) {
   const queryBuilder = new Querybuilder();
 
   const { language, showDataAll } = params;
@@ -53,7 +45,7 @@ async function getSingleItem(params) {
     hits: result.body.responses[0].hits.total.value,
   };
 
-  const results = Aggregator.aggregateESResult(result.body.responses[0], showDataAll);
+  const results = Aggregator.aggregateESResult(result.body.responses[0], mappings, showDataAll);
 
   return {
     meta,
@@ -61,25 +53,21 @@ async function getSingleItem(params) {
   };
 }
 
-async function getItems(req, params) {
+async function getItems(mappings, req, params) {
 
   const queryBuilder = new Querybuilder();
 
   // Subresource was setted
   if (params.entityType) {
-    const mapping = getMappingByKey('entity_type');
+    const entityTypeMapping = mappings.getMappingByKey('entity_type');
     const entityFilter = {
       key: 'entity_type',
-      values: [entityTypes[params.entityType]],
-      valueField: mapping.value,
+      values: [Mappings.entityTypes[params.entityType]],
+      valueField: entityTypeMapping.value,
       operator: 'eq',
     }
 
     queryBuilder.must(entityFilter);
-
-    // Overwrite mappings
-    const { mappings } = require(`../mappings/${params.entityType}`)
-    setMappings( mappings );
   }
 
   const { language, showDataAll } = params;
@@ -119,14 +107,14 @@ async function getItems(req, params) {
           secondFilter.operator = 'gte';
           secondFilter.key = 'dating_end';
           queryBuilder.softRange(filter, secondFilter);
-          queryBuilder.sortBy(new SortParam(getMappingByKey('score').value, 'desc'));
+          queryBuilder.sortBy(new SortParam(mappings.getMappingByKey('score').value, 'desc'));
         } else if (filter.key === 'dating_end' && filter.operator === 'lte') {
           const secondFilter = { ...filter };
           secondFilter.valueField = 'dating.begin';
           secondFilter.operator = 'lte';
           secondFilter.key = 'dating_begin';
           queryBuilder.softRange(filter, secondFilter);
-          queryBuilder.sortBy(new SortParam(getMappingByKey('score').value, 'desc'));
+          queryBuilder.sortBy(new SortParam(mappings.getMappingByKey('score').value, 'desc'));
         } else {
           queryBuilder.range(filter);
         }
@@ -146,7 +134,7 @@ async function getItems(req, params) {
     queryBuilder.sortBy(sortParamObject);
   });
 
-  visibleFilters.forEach((filter) => {
+  mappings.getVisibleFilters().forEach((filter) => {
     const aggregationParam = new AggregationParam(
       filter.key,
       filter.value,
@@ -164,12 +152,14 @@ async function getItems(req, params) {
     aggregations: result.body.responses[0].aggregations,
     setAsAvailable: false,
     allFilters: true,
+    mappings,
   });
 
   // Aggregate filtered filter buckets
   const aggregationsFiltered = Aggregator.aggregateESFilterBuckets({
     aggregations: result.body.responses[1].aggregations,
     setAsAvailable: true,
+    mappings,
   });
 
   // Aggregate filter buckets of multi filters
@@ -180,6 +170,7 @@ async function getItems(req, params) {
     const currentAggregation = Aggregator.aggregateESFilterBuckets({
       aggregations: result.body.responses[currentIndex + 2].aggregations,
       setAsAvailable: true,
+      mappings,
     });
 
     const filterKey = searchParamsMultiFilter.key;
@@ -196,7 +187,7 @@ async function getItems(req, params) {
     const filterInfosClone = JSON.parse(JSON.stringify(filterInfos[req.language]));
 
     // Aggregate filterInfos filter
-    if (isFilterInfosFilter(aggregationKey)) {
+    if (mappings.isFilterInfosFilter(aggregationKey)) {
       const currentFilterInfos = filterInfosClone.find(filter => filter.id === aggregationKey);
       Aggregator.aggregateFilterInfos(currentFilterInfos.children, currentAggregationFiltered);
       aggregationsAll[aggregationKey] = {
@@ -240,7 +231,7 @@ async function getItems(req, params) {
     hits: result.body.responses[1].hits.total.value,
   };
 
-  const results = Aggregator.aggregateESResult(result.body.responses[1], showDataAll);
+  const results = Aggregator.aggregateESResult(result.body.responses[1], mappings, showDataAll);
 
   const ret = {};
   ret.meta = meta;

--- a/src/server/query-params-parser/index.js
+++ b/src/server/query-params-parser/index.js
@@ -28,7 +28,7 @@ function validateSearchTermParams(req, mappings) {
   req.api.searchtermParams = resultSearchtermParams;
 }
 
-function validateSortParams(req, mappings) {
+function validateSortParams(req, res, mappings) {
   const filterParamsQuery = req.query;
   const sortableFields = mappings.getSortableFields();
   const resultSortParams = [];
@@ -72,7 +72,7 @@ function validateSortParams(req, mappings) {
   req.api.sortParams = resultSortParams;
 }
 
-function validateFilterParams(req, mappings) {
+function validateFilterParams(req, res, mappings) {
   const filterParamsQuery = req.query;
   const filterParamsKeys = Object.keys(filterParamsQuery);
   const resultFilterParams = [];
@@ -90,6 +90,7 @@ function validateFilterParams(req, mappings) {
     const filterTypeGroup = Mappings.availableFilterTypes[filterType];
     if (filterTypeGroup === undefined) {
       res.status(500).json({ success: false, error: `Not allowed filter type <${filterType}>` });
+      res.end();
     }
 
     const filteredFilter = allowedFilters.filter(
@@ -99,14 +100,17 @@ function validateFilterParams(req, mappings) {
     // TODO: Operation überprüfen. => macht semantisch nicht das Richtige
     if (filteredFilter.length > 1) {
       res.status(500).json({ success: false, error: `filter key <${filterKey}> assigned serveral times` });
+      res.end();
     }
 
     if (filteredFilter.length === 0) {
       res.status(500).json({ success: false, error: `Not allowed filter key <${filterKey}>` });
+      res.end();
     }
 
     if (!filteredFilter[0].filter_types.includes(filterTypeGroup)) {
       res.status(500).json({ success: false, error: `Not allowed filter type <${filterType}> for filter key <${filterKey}>` });
+      res.end();
     }
 
     let filterValues = [];
@@ -152,8 +156,8 @@ function validateParams(mappings) {
     req.api = {};
 
     validateSearchTermParams(req, mappings);
-    validateSortParams(req, mappings);
-    validateFilterParams(req, mappings);
+    validateSortParams(req, res, mappings);
+    validateFilterParams(req, res, mappings);
     validatePaginationParams(req);
     next();
   };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -12,6 +12,13 @@ const archivalsMappings = new Mappings(MappingType.ARCHIVALS);
 
 routes.route('/').get(
   passport.authenticate('basic', { session: false }),
+  // INFO: mappings for works are also used for archivals;
+  // it would be possible to introduce and use default mappings containing overlapping fields
+  queryParamsParser.validateParams(worksMappings),
+  controller.getItems(worksMappings),
+);
+routes.route('/works').get(
+  passport.authenticate('basic', { session: false }),
   queryParamsParser.validateParams(worksMappings),
   controller.getItems(worksMappings),
 );

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -2,11 +2,27 @@ const express = require('express');
 const passport = require('passport');
 
 const controller = require('../controllers');
+const { Mappings, MappingType } = require('../mappings');
+const queryParamsParser = require('../query-params-parser');
 
 const routes = express.Router();
 
-routes.route('/').get(passport.authenticate('basic', { session: false }), controller.getItems);
-routes.route('/archivals').get(passport.authenticate('basic', { session: false }), controller.getItems);
-routes.route('/:id').get(passport.authenticate('basic', { session: false }), controller.getSingleItem);
+const worksMappings = new Mappings(MappingType.WORKS);
+const archivalsMappings = new Mappings(MappingType.ARCHIVALS);
+
+routes.route('/').get(
+  passport.authenticate('basic', { session: false }),
+  queryParamsParser.validateParams(worksMappings),
+  controller.getItems(worksMappings),
+);
+routes.route('/archivals').get(
+  passport.authenticate('basic', { session: false }),
+  queryParamsParser.validateParams(archivalsMappings),
+  controller.getItems(archivalsMappings),
+);
+routes.route('/:id').get(
+  passport.authenticate('basic', { session: false }),
+  controller.getSingleItem(worksMappings), // INFO: using works-mapping for all kinds of resources for now
+);
 
 module.exports = routes;


### PR DESCRIPTION
Mit diesem MR wird die Handhabung der Mappings etwas überarbeitet.

Es gibt nun eine Mappings-Klasse, die abhängig eines angegebenen Typs die korrekten mappings zieht. Im Rahmen einer solchen Instanz, werden die zuvor existierenden Mapping-Funktionen (u.a. `getAllowedFilters`) automatisch auf Basis der korrekten Mappings aufgerufen.

Zudem wird beim Aggregieren der Filter nun auch zusätzlich nach Entity-Typen gefiltert, da sonst eine Abfrage der Filter für die Archivalien auch Filter-Werte zurückgeben würde, die nur für Gemälde und Grafiken Sinn machen.
Der Grund dafür liegt darin, dass Gemälde, Grafiken und Archivalien in einem ES-Index vorliegen, weshalb Filter-Werte auch über den ganzen Index zusammengetragen werden bzw. wurden.